### PR TITLE
Build fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "env-cmd": "^10.1.0",
     "events": "^3.3.0",
     "nodemon": "^2.0.16",
-    "parcel": "^2.7.0",
+    "parcel": "~2.7.0",
     "process": "^0.11.10"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "npm run build:contract && npm run build:web",
     "build:web": "cd frontend && npm run build",
     "build:contract": "cd contract && ./build.sh",
-    "test": "npm run build:contract && npm run test:unit && npm run test:integration",
+    "test": "npm run test:unit && npm run test:integration",
     "test:unit": "cd contract && cargo test",
-    "test:integration": "cd integration-tests && npm test -- -- \"./contract/target/wasm32-unknown-unknown/release/contract.wasm\"",
+    "test:integration": "npm run build:contract && cd integration-tests && npm test -- -- \"./contract/target/wasm32-unknown-unknown/release/contract.wasm\"",
     "postinstall": "cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && echo rs contract"
   },
   "devDependencies": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69"


### PR DESCRIPTION
This PR contains three small build fixes.

**b075ff2b55d21616a9f66166b557bbcebb121a00 fix: pin parcel dependency to 2.7**

Required as build is failing with newer versions.

**d17e63a6997f2be3c71e788f8921790115c97c65 fix: build contract before integration test**

The `test:integration` task depends on the `build:contract` task, but
it's currently ran as part of the `test` task so if a user just
runs `test:integration` it may fail or run with an outdated build.

The same change was made in `create-near-app`:
https://github.com/near/create-near-app/pull/2014

**5df4adebaf3516f825d9dab4e95af070b29cea58 fix: use Rust 1.69**

The latest released `nearcore` currently doesn't support Rust 1.70.
This commit fixes that for users who use `rustup` by pinning the
Rust version to 1.69.

Motivated by https://github.com/near/near-sdk-rs/issues/1035

